### PR TITLE
update: use latest

### DIFF
--- a/src/crates.rs
+++ b/src/crates.rs
@@ -140,7 +140,7 @@ impl Krate {
         }
         let sh = Shell::new()?;
         let name = self.name();
-        let version = self.version();
+        let version = &self.latest;
         cmd!(sh, "cargo add {name}@{version}").run()?;
 
         Ok(())


### PR DESCRIPTION
This PR fixes the updating functionality.

Before it used the current version of the crate instead of the new version.